### PR TITLE
Plumbing for AWS IAM authenticator

### DIFF
--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -12,4 +12,6 @@ module "bootkube" {
   service_cidr          = "${var.service_cidr}"
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
   cloud_provider        = "aws"
+  cluster_id = "${var.cluster_id}"
+  admin_role_arns = "${var.admin_role_arns}"
 }

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -134,3 +134,13 @@ variable "cluster_domain_suffix" {
   type        = "string"
   default     = "cluster.local"
 }
+
+variable "cluster_id" {
+  description = "The identifier for the cluster for AWS IAM authentication purposes"
+  type = "string"
+}
+
+variable "admin_role_arns" {
+  description = "A list of ARNs that will be mapped to cluster administrators"
+  type = "list"
+}


### PR DESCRIPTION
All the work is done in the bootkube renderer so this is effectively a pass-through.

- [x] Merge https://github.com/alphagov/terraform-render-bootkube/pull/1
- [x] Update the bootkube reference in aws/container-linux/kubernetes/bootkube.tf to point at `gsp` instead of `iam_auth`

Solo: @blairboy362 